### PR TITLE
Handle null values on query results

### DIFF
--- a/Sources/SQLite.swift
+++ b/Sources/SQLite.swift
@@ -63,7 +63,10 @@ public class SQLite {
                 let text = sqlite3_column_text(statement, i)
                 let name = sqlite3_column_name(statement, i)
 
-                let value = String(cString: UnsafePointer(text))
+                var value: String? = nil
+                if let text = text {
+                    value = String(cString: UnsafePointer(text))
+                }
                 let column = String(cString: name)
 
                 row.data[column] = value


### PR DESCRIPTION
When parsing the text from the query result, the null values was giving me an nulll exception, i just added a null checking to prevent this from happening
