### PR TITLE
Add fix for SQLite strings being coerced to numbers internally

### DIFF
--- a/Sources/FluentSQLite/SQLiteDriver.swift
+++ b/Sources/FluentSQLite/SQLiteDriver.swift
@@ -28,7 +28,7 @@ public class SQLiteDriver: Fluent.Driver {
     */
     @discardableResult
     public func query<T: Entity>(_ query: Query<T>) throws -> Node {
-        let serializer = GeneralSQLSerializer(sql: query.sql)
+        let serializer = SQLiteSerializer(sql: query.sql)
         let (statement, values) = serializer.serialize()
         let results = try database.execute(statement) { statement in
             try self.bind(statement: statement, to: values)
@@ -42,7 +42,7 @@ public class SQLiteDriver: Fluent.Driver {
     }
 
     public func schema(_ schema: Schema) throws {
-      let serializer = GeneralSQLSerializer(sql: schema.sql)
+      let serializer = SQLiteSerializer(sql: schema.sql)
       let (statement, values) = serializer.serialize()
       try _ = raw(statement, values)
     }

--- a/Sources/FluentSQLite/SQLiteSerializer.swift
+++ b/Sources/FluentSQLite/SQLiteSerializer.swift
@@ -1,0 +1,21 @@
+import Fluent
+import SQLite
+
+/**
+    SQLite-specific overrides for the GeneralSQLSerializer
+  */
+public class SQLiteSerializer: GeneralSQLSerializer {
+    /**
+        Serializes a SQLite data type.
+      */
+    public override func sql(_ type: Schema.Field.DataType) -> String {
+        // SQLite has a design where any data type that does not contain `TEXT`,
+        // `CLOB`, or `CHAR` will be treated with `NUMERIC` affinity.
+        // All SQLite `STRING` fields should instead be declared with `TEXT`.
+        // More information: https://www.sqlite.org/datatype3.html
+        if case .string(_)  = type {
+            return "TEXT"
+        }
+        return super.sql(type)
+    }
+}


### PR DESCRIPTION
SQLite has a neat "feature" where any data type that does not contain `TEXT`, `CLOB`, or `CHAR` will be treated with `NUMERIC` affinity.
All SQLite `STRING` fields should instead be declared with `TEXT`

This also adds a test that ensures that a string containing a large number will remain encoded as a string and not get coerced to a number internally.

More information: https://www.sqlite.org/datatype3.html

This new test fails miserably (the data is returned as "Inf" instead of the long string of 1s) with the old behavior, and passes with the new.
