### PR TITLE
Implements count functionality to queries

### DIFF
--- a/Sources/FluentSQLite/SQLiteDriver.swift
+++ b/Sources/FluentSQLite/SQLiteDriver.swift
@@ -36,6 +36,12 @@ public class SQLiteDriver: Fluent.Driver {
 
         if let id = database.lastId, query.action == .create {
             return try id.makeNode()
+        } else if query.action == .count {
+            guard let (_, value) = results.first?.data.first,
+                let count = Int(value) else {
+                return .number(.int(0))
+            }
+            return .number(.int(count))
         } else {
             return map(results: results)
         }


### PR DESCRIPTION
This is part of a series of pull requests to implement the count functionality for queries in Fluent. This addition allows to quickly determine the number of results of a query, without retrieving and parsing any data from the database.

There is also a pull request for Fluent (vapor/fluent#115).
