### PR TITLE
Adapted Fluent driver to conform to possibly new SQLite DataType type

### DIFF
--- a/Sources/FluentSQLite/SQLiteDriver.swift
+++ b/Sources/FluentSQLite/SQLiteDriver.swift
@@ -37,7 +37,7 @@ public class SQLiteDriver: Fluent.Driver {
         if let id = database.lastId, query.action == .create {
             return try id.makeNode()
         } else {
-            return map(results: results)
+            return try map(results: results)
         }
     }
 
@@ -56,7 +56,7 @@ public class SQLiteDriver: Fluent.Driver {
         let results = try database.execute(statement) { statement in
             try self.bind(statement: statement, to: values)
         }
-        return map(results: results)
+        return try map(results: results)
     }
 
     /**
@@ -94,15 +94,24 @@ public class SQLiteDriver: Fluent.Driver {
     /**
         Maps SQLite Results to Fluent results.
     */
-    func map(results: [SQLite.Result.Row]) -> Node {
-        let res: [Node] = results.map { row in
+    func map(results: [SQLite.Result.Row]) throws -> Node {
+        let nodes: [Node] = try results.map { row in
             var object: Node = .object([:])
             for (key, value) in row.data {
-                object[key] = value.makeNode()
+                switch value {
+                case .text(let string):
+                    object[key] = string.makeNode()
+                case .integer(let integer):
+                    object[key] = try integer.makeNode()
+                case .double(let double):
+                    object[key] = double.makeNode()
+                case .null:
+                    object[key] = .null
+                }
             }
             return object
         }
-        return .array(res)
+        return .array(nodes)
     }
 
 }


### PR DESCRIPTION
_Does not build_
## Introduction

In reference to [SQLite#12](https://github.com/vapor/sqlite/pull/12), this PR adapts the `map` function to give a proper type to nodes according to new SQLite.DataType enum.
## Impact

This wouldn't have any impact on existing code unless developers converted the strings that were returned themselves.
