### PR TITLE
Upgrade to Fluent 1.3 and add Serializer test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Sources/main.swift
 Packages
 Database
 *.xcodeproj
+database.db

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "FluentSQLite",
     dependencies: [
         .Package(url: "https://github.com/vapor/sqlite.git", majorVersion: 1, minor: 0),
-        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 0),
+        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 3),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "FluentSQLite",
     dependencies: [
-        .Package(url: "https://github.com/vapor/sqlite.git", majorVersion: 1, minor: 0),
-        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 3),
+        .Package(url: "https://github.com/vapor/sqlite.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1),
     ]
 )

--- a/Tests/FluentSQLiteTests/SQLiteSerializerTests.swift
+++ b/Tests/FluentSQLiteTests/SQLiteSerializerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import FluentSQLite
+@testable import Fluent
+
+class SQLiteSerializerTests : XCTestCase {
+    static var allTests: [(String, (SQLiteSerializerTests) -> () throws -> Void)] {
+        return [
+            ("testSql", testSql)
+        ]
+    }
+
+    var serializer:SQLiteSerializer!
+
+    func testSql() {
+        serializer = SQLiteSerializer(sql: SQL.count(table: "testTable", filters: [], joins: []))
+        let (output, nodes) = serializer.serialize()
+        XCTAssertEqual(output, "SELECT COUNT(*) as _fluent_count FROM `testTable`")
+        XCTAssertEqual(nodes, [])
+    }
+}

--- a/Tests/FluentSQLiteTests/SQLiteSerializerTests.swift
+++ b/Tests/FluentSQLiteTests/SQLiteSerializerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Fluent
 
 class SQLiteSerializerTests : XCTestCase {
-    static var allTests: [(String, (SQLiteSerializerTests) -> () throws -> Void)] {
+    static let allTests = {
         return [
             ("testSql", testSql)
         ]

--- a/Tests/FluentSQLiteTests/Utilities/Atom.swift
+++ b/Tests/FluentSQLiteTests/Utilities/Atom.swift
@@ -4,6 +4,7 @@ final class Atom: Entity {
     var id: Node?
     var name: String
     var protons: Int
+    var exists: Bool = false
 
     init(name: String, protons: Int) {
         self.name = name

--- a/Tests/FluentSQLiteTests/Utilities/Compound.swift
+++ b/Tests/FluentSQLiteTests/Utilities/Compound.swift
@@ -3,6 +3,7 @@ import Fluent
 final class Compound: Entity {
     var id: Node?
     var name: String
+    var exists: Bool = false
 
     init(name: String) {
         self.name = name

--- a/Tests/FluentSQLiteTests/Utilities/Post.swift
+++ b/Tests/FluentSQLiteTests/Utilities/Post.swift
@@ -11,6 +11,7 @@ final class Post: Entity {
     var id: Fluent.Node?
     var title: String
     var text: String
+    var exists: Bool = false
     
     init(id: Node?, title: String, text: String) {
         self.id = id


### PR DESCRIPTION
This PR is the first step to getting [the fluent-example updated to the latest version of Fluent](https://github.com/vapor/fluent-example).

The `SQLiteSerializer` logic is likely already [well-tested](https://github.com/vapor/sqlite-driver/blob/master/Tests/FluentSQLiteTests/SQLiteDriverTests.swift#L67) so if y'all would prefer I delete the file (or have other feedback) please let me know!

I added the `exists` field following the deprecation warning:

```
[DEPRECATED] No 'exists' property is stored on 'Compound'. Add `var exists: Bool = false` to this model. The default implementation will be removed in a future update.
```